### PR TITLE
Fixed error thrown while using contentLoader with BorderRadius

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ class ContentLoader extends PureComponent {
     const avatarInitialStyles = {
       height: AVATAR_SIZE[aSize] || aSize,
       width: AVATAR_SIZE[aSize] || aSize,
-      borderRadius: aShape === "circle" ? "50%" : 3,
+      borderRadius: aShape === "circle" ? AVATAR_SIZE[aSize]/2 || aSize/2 : 3,
       marginRight: reverse ? 0 : 10,
       marginLeft: reverse ? 10 : 0
     };


### PR DESCRIPTION
Hi Sarmad! Nice Work here.

I was looking for a substitute to the _**react-native-loading-placeholder**_ (because it was throwing an error on android and the error was beyond what I can fix). I found your solution and the simplicity in it blew me away. Thanks a lot.

So, while using the project, I realized the **`ContentLoader`** was throwing an error if the **`avatar`** props was present. It was a familiar error to me so I dug into your source code to see if I could fix it. React Native couldn't interpret the **_`borderRadius: 50%`_** so I decided to help myself.

Please look through the fix and determine if you would love to merge it with your present work.

Thanks once again for this free solution.