### PR TITLE
Add useNativeDriver property to timing

### DIFF
--- a/src/shared.tsx
+++ b/src/shared.tsx
@@ -15,11 +15,13 @@ export const startAnimationHelper = (animation: AnimationType, duration: number)
     Animated.sequence([
       Animated.timing(animation, {
         toValue: 1,
-        duration
+        duration,
+        useNativeDriver: false
       }),
       Animated.timing(animation, {
         toValue: 0,
-        duration
+        duration,
+        useNativeDriver: false
       })
     ])
   ).start();


### PR DESCRIPTION
In react-native 0.62 the useNativeDriver property is now required, this will remove the warning.